### PR TITLE
Fix CI: capture non-zero exit codes in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,12 @@ jobs:
             fi
 
             # Run both and capture output + exit code
-            gcc_out=$("/tmp/gcc_${test_name}" 2>&1) || true
+            set +e
+            gcc_out=$("/tmp/gcc_${test_name}" 2>&1)
             gcc_rc=$?
-            rustcc_out=$("/tmp/rustcc_${test_name}" 2>&1) || true
+            rustcc_out=$("/tmp/rustcc_${test_name}" 2>&1)
             rustcc_rc=$?
+            set -e
 
             # Compare expected return code if specified
             if [ -f "$test_dir/expected.ret" ]; then


### PR DESCRIPTION
## Summary
- Fix bug in integration test script where `|| true` after command substitution caused `$?` to always return 0
- Tests expecting non-zero exit codes (return_constant=42, arithmetic=13, for_loop=45, etc.) were all reporting `got=0`
- Replace `|| true` with `set +e` / `set -e` to properly capture exit codes while still preventing script abort

## Test plan
- [x] Rust build + test + lint still pass
- [ ] Integration tests should now correctly capture non-zero exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)