### PR TITLE
Fix missing labels in IR for nested control flow

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -196,10 +196,10 @@ impl FunctionBuilder {
     }
 
     fn finish(mut self) -> Function {
-        // If current block has instructions but no terminator, add implicit return
-        if !self.current_block.is_empty() {
-            self.terminate(Terminator::Return(Some(Operand::Immediate(0))));
-        }
+        // Always finalize the current block — even if it's empty, it may be
+        // a branch target that other blocks jump to.  Give it an implicit
+        // return so the assembler always finds the label.
+        self.terminate(Terminator::Return(Some(Operand::Immediate(0))));
         Function {
             name: self.name,
             params: self.params,


### PR DESCRIPTION
## Summary
- Fixes `nested_if` integration test failure ("rustcc failed to compile")
- When all branches of an if/else contain return statements, the merge block label was never emitted
- `FunctionBuilder::finish()` only finalized the current block if it had instructions, but merge blocks can be empty branch targets
- Fix: always finalize the current block in `finish()`, ensuring every referenced label exists in the assembly output

## Root cause
In nested if/else where all paths return:
```c
if (x > 10) {
    if (x > 20) { return 3; }
    else { return 2; }
} else { return 1; }
```
The IR lowering creates merge-point labels (e.g., `.Lmain_3`, `.Lmain_6`) that other blocks jump to. But these merge blocks are empty (all paths already returned), and `finish()` skipped empty blocks. The assembler then fails on undefined label references.

## Test plan
- [x] All 14 unit tests pass
- [x] `cargo clippy -- -D warnings` passes  
- [x] `cargo fmt -- --check` passes
- [x] Nested if/else with all-return branches now generates valid assembly

🤖 Generated with [Claude Code](https://claude.com/claude-code)