### PR TITLE
Add AArch64 codegen, fix IR merge blocks, add integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,440 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rustcc"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,4 +1,4 @@
-/// x86-64 code generator (AT&T syntax).
+/// Code generator with x86-64 and AArch64 backends.
 /// Naive: every virtual register gets a stack slot.
 use crate::ir::{
     BasicBlock, CmpOp, Function, Instruction, IrBinOp, IrUnaryOp, Module, Operand, Terminator, VReg,
@@ -6,19 +6,55 @@ use crate::ir::{
 use std::collections::HashMap;
 use std::fmt::Write;
 
-/// System V AMD64 ABI argument registers
-const ARG_REGS: [&str; 6] = ["%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9"];
+/// Dispatch to the appropriate backend based on target architecture.
+pub fn generate(module: &Module) -> String {
+    if cfg!(target_arch = "aarch64") {
+        let mut codegen = Aarch64CodeGen::new();
+        codegen.generate_module(module);
+        codegen.output
+    } else {
+        let mut codegen = X86CodeGen::new();
+        codegen.generate_module(module);
+        codegen.output
+    }
+}
 
-struct CodeGen {
+fn escape_string_for_gas(s: &str) -> String {
+    let mut result = String::new();
+    for c in s.chars() {
+        match c {
+            '\n' => result.push_str("\\n"),
+            '\t' => result.push_str("\\t"),
+            '\r' => result.push_str("\\r"),
+            '\\' => result.push_str("\\\\"),
+            '"' => result.push_str("\\\""),
+            '\0' => result.push_str("\\0"),
+            c if c.is_ascii_graphic() || c == ' ' => result.push(c),
+            c => {
+                let b = c as u32;
+                write!(result, "\\{:03o}", b).unwrap();
+            }
+        }
+    }
+    result
+}
+
+// ============================================================================
+// x86-64 Code Generator (AT&T syntax, System V AMD64 ABI)
+// ============================================================================
+
+/// System V AMD64 ABI argument registers
+const X86_ARG_REGS: [&str; 6] = ["%rdi", "%rsi", "%rdx", "%rcx", "%r8", "%r9"];
+
+struct X86CodeGen {
     output: String,
-    /// Map from vreg to stack offset (negative from rbp)
     stack_slots: HashMap<VReg, i32>,
     stack_size: i32,
 }
 
-impl CodeGen {
+impl X86CodeGen {
     fn new() -> Self {
-        CodeGen {
+        X86CodeGen {
             output: String::new(),
             stack_slots: HashMap::new(),
             stack_size: 0,
@@ -47,7 +83,6 @@ impl CodeGen {
         writeln!(self.output, "{}", line).unwrap();
     }
 
-    /// Load an operand into %rax
     fn load_operand_rax(&mut self, op: &Operand) {
         match op {
             Operand::Immediate(val) => {
@@ -60,7 +95,6 @@ impl CodeGen {
         }
     }
 
-    /// Load an operand into %rcx
     fn load_operand_rcx(&mut self, op: &Operand) {
         match op {
             Operand::Immediate(val) => {
@@ -73,19 +107,16 @@ impl CodeGen {
         }
     }
 
-    /// Store %rax to a vreg's stack slot
     fn store_rax(&mut self, vreg: VReg) {
         let offset = self.slot_for(vreg);
         self.emit_line(&format!("movq %rax, {}(%rbp)", offset));
     }
 
     fn generate_module(&mut self, module: &Module) {
-        // String literals in .rodata
         if !module.string_literals.is_empty() {
             self.emit_raw("    .section .rodata");
             for (label, value) in &module.string_literals {
                 self.emit_label(label);
-                // Emit as escaped string
                 let escaped = escape_string_for_gas(value);
                 self.emit_line(&format!(".string \"{}\"", escaped));
             }
@@ -104,35 +135,30 @@ impl CodeGen {
         self.stack_slots.clear();
         self.stack_size = 0;
 
-        // Pre-allocate all vreg stack slots
         for vreg in 0..func.num_vregs {
             self.slot_for(vreg);
         }
 
-        // Align stack to 16 bytes
         let aligned_stack = (self.stack_size + 15) & !15;
 
         self.emit_raw(&format!("    .globl {}", func.name));
         self.emit_label(&func.name);
 
-        // Prologue
         self.emit_line("pushq %rbp");
         self.emit_line("movq %rsp, %rbp");
         if aligned_stack > 0 {
             self.emit_line(&format!("subq ${}, %rsp", aligned_stack));
         }
 
-        // Save arguments to stack slots
         for (i, param_name) in func.params.iter().enumerate() {
-            if i < ARG_REGS.len() && !param_name.is_empty() {
+            if i < X86_ARG_REGS.len() && !param_name.is_empty() {
                 if let Some(&vreg) = func.locals.get(param_name) {
                     let offset = self.slot_for(vreg);
-                    self.emit_line(&format!("movq {}, {}(%rbp)", ARG_REGS[i], offset));
+                    self.emit_line(&format!("movq {}, {}(%rbp)", X86_ARG_REGS[i], offset));
                 }
             }
         }
 
-        // Generate basic blocks
         for block in &func.blocks {
             self.generate_block(block, &func.name);
         }
@@ -167,24 +193,19 @@ impl CodeGen {
                     IrBinOp::Sub => self.emit_line("subq %rcx, %rax"),
                     IrBinOp::Mul => self.emit_line("imulq %rcx, %rax"),
                     IrBinOp::Div => {
-                        self.emit_line("cqto"); // sign-extend rax into rdx:rax
+                        self.emit_line("cqto");
                         self.emit_line("idivq %rcx");
                     }
                     IrBinOp::Mod => {
                         self.emit_line("cqto");
                         self.emit_line("idivq %rcx");
-                        self.emit_line("movq %rdx, %rax"); // remainder in rdx
+                        self.emit_line("movq %rdx, %rax");
                     }
                     IrBinOp::And => self.emit_line("andq %rcx, %rax"),
                     IrBinOp::Or => self.emit_line("orq %rcx, %rax"),
                     IrBinOp::Xor => self.emit_line("xorq %rcx, %rax"),
-                    IrBinOp::Shl => {
-                        // shift amount must be in %cl
-                        self.emit_line("shlq %cl, %rax");
-                    }
-                    IrBinOp::Shr => {
-                        self.emit_line("sarq %cl, %rax");
-                    }
+                    IrBinOp::Shl => self.emit_line("shlq %cl, %rax"),
+                    IrBinOp::Shr => self.emit_line("sarq %cl, %rax"),
                 }
                 self.store_rax(*dest);
             }
@@ -227,44 +248,19 @@ impl CodeGen {
                 self.store_rax(*dest);
             }
             Instruction::Call { dest, func, args } => {
-                // Push args into argument registers (System V ABI)
-                // Need to be careful about register clobbering
-                // First, push all args to stack, then pop into arg regs
-                let num_reg_args = args.len().min(ARG_REGS.len());
-
-                // Evaluate and store args on stack temporarily
-                let mut arg_temps = Vec::new();
                 for arg in args {
                     self.load_operand_rax(arg);
                     self.emit_line("pushq %rax");
-                    arg_temps.push(());
                 }
-
-                // Pop into arg registers in reverse order
                 for i in (0..args.len()).rev() {
-                    if i < ARG_REGS.len() {
-                        self.emit_line(&format!("popq {}", ARG_REGS[i]));
+                    if i < X86_ARG_REGS.len() {
+                        self.emit_line(&format!("popq {}", X86_ARG_REGS[i]));
                     } else {
-                        // Stack args stay on stack - but we need to handle this properly
-                        // For now, just pop and discard extras
                         self.emit_line("popq %rax");
                     }
                 }
-
-                // For variadic functions (like printf), set %al = number of vector args (0)
                 self.emit_line("xorl %eax, %eax");
-
-                // Align stack to 16 bytes before call if needed
-                // The stack is already 16-byte aligned after prologue if we haven't pushed odd items
-                let stack_args = if args.len() > ARG_REGS.len() {
-                    args.len() - ARG_REGS.len()
-                } else {
-                    0
-                };
-                let _ = (stack_args, num_reg_args, arg_temps);
-
                 self.emit_line(&format!("call {}", func));
-
                 if let Some(dest) = dest {
                     self.store_rax(*dest);
                 }
@@ -316,38 +312,339 @@ impl CodeGen {
                 self.emit_line(&format!("jne .L{}_{}", func_name, true_label));
                 self.emit_line(&format!("jmp .L{}_{}", func_name, false_label));
             }
-            Terminator::None => {
-                // Should not happen in well-formed IR
-            }
+            Terminator::None => {}
         }
     }
 }
 
-fn escape_string_for_gas(s: &str) -> String {
-    let mut result = String::new();
-    for c in s.chars() {
-        match c {
-            '\n' => result.push_str("\\n"),
-            '\t' => result.push_str("\\t"),
-            '\r' => result.push_str("\\r"),
-            '\\' => result.push_str("\\\\"),
-            '"' => result.push_str("\\\""),
-            '\0' => result.push_str("\\0"),
-            c if c.is_ascii_graphic() || c == ' ' => result.push(c),
-            c => {
-                // Emit as octal escape
-                let b = c as u32;
-                write!(result, "\\{:03o}", b).unwrap();
+// ============================================================================
+// AArch64 Code Generator (AAPCS64)
+// ============================================================================
+
+/// AAPCS64: first 8 integer args in x0-x7
+const AARCH64_ARG_REGS: [&str; 8] = ["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"];
+
+struct Aarch64CodeGen {
+    output: String,
+    /// Map from vreg to stack offset (positive from sp)
+    stack_slots: HashMap<VReg, i32>,
+    /// Total stack frame size (including saved fp/lr)
+    stack_size: i32,
+}
+
+impl Aarch64CodeGen {
+    fn new() -> Self {
+        Aarch64CodeGen {
+            output: String::new(),
+            stack_slots: HashMap::new(),
+            stack_size: 16, // Reserve 16 bytes for saved fp (x29) and lr (x30)
+        }
+    }
+
+    fn slot_for(&mut self, vreg: VReg) -> i32 {
+        if let Some(&offset) = self.stack_slots.get(&vreg) {
+            return offset;
+        }
+        let offset = self.stack_size;
+        self.stack_size += 8;
+        self.stack_slots.insert(vreg, offset);
+        offset
+    }
+
+    fn emit_line(&mut self, line: &str) {
+        writeln!(self.output, "    {}", line).unwrap();
+    }
+
+    fn emit_label(&mut self, label: &str) {
+        writeln!(self.output, "{}:", label).unwrap();
+    }
+
+    fn emit_raw(&mut self, line: &str) {
+        writeln!(self.output, "{}", line).unwrap();
+    }
+
+    /// Load an operand into x0
+    fn load_operand_x0(&mut self, op: &Operand) {
+        match op {
+            Operand::Immediate(val) => {
+                self.load_immediate("x0", *val);
+            }
+            Operand::VReg(vreg) => {
+                let offset = self.slot_for(*vreg);
+                self.emit_line(&format!("ldr x0, [sp, #{}]", offset));
             }
         }
     }
-    result
-}
 
-pub fn generate(module: &Module) -> String {
-    let mut codegen = CodeGen::new();
-    codegen.generate_module(module);
-    codegen.output
+    /// Load an operand into x1
+    fn load_operand_x1(&mut self, op: &Operand) {
+        match op {
+            Operand::Immediate(val) => {
+                self.load_immediate("x1", *val);
+            }
+            Operand::VReg(vreg) => {
+                let offset = self.slot_for(*vreg);
+                self.emit_line(&format!("ldr x1, [sp, #{}]", offset));
+            }
+        }
+    }
+
+    /// Load an immediate value into a register (handles large constants)
+    fn load_immediate(&mut self, reg: &str, val: i64) {
+        if (-65536..=65535).contains(&val) {
+            self.emit_line(&format!("mov {}, #{}", reg, val));
+        } else {
+            // Large constants: use movz + movk sequence
+            let uval = val as u64;
+            self.emit_line(&format!("movz {}, #0x{:x}", reg, uval & 0xFFFF));
+            if (uval >> 16) & 0xFFFF != 0 {
+                self.emit_line(&format!(
+                    "movk {}, #0x{:x}, lsl #16",
+                    reg,
+                    (uval >> 16) & 0xFFFF
+                ));
+            }
+            if (uval >> 32) & 0xFFFF != 0 {
+                self.emit_line(&format!(
+                    "movk {}, #0x{:x}, lsl #32",
+                    reg,
+                    (uval >> 32) & 0xFFFF
+                ));
+            }
+            if (uval >> 48) & 0xFFFF != 0 {
+                self.emit_line(&format!(
+                    "movk {}, #0x{:x}, lsl #48",
+                    reg,
+                    (uval >> 48) & 0xFFFF
+                ));
+            }
+        }
+    }
+
+    /// Store x0 to a vreg's stack slot
+    fn store_x0(&mut self, vreg: VReg) {
+        let offset = self.slot_for(vreg);
+        self.emit_line(&format!("str x0, [sp, #{}]", offset));
+    }
+
+    fn generate_module(&mut self, module: &Module) {
+        if !module.string_literals.is_empty() {
+            self.emit_raw("    .section .rodata");
+            for (label, value) in &module.string_literals {
+                self.emit_label(label);
+                let escaped = escape_string_for_gas(value);
+                self.emit_line(&format!(".string \"{}\"", escaped));
+            }
+            self.emit_raw("");
+        }
+
+        self.emit_raw("    .text");
+        for func in &module.functions {
+            if func.is_defined {
+                self.generate_function(func);
+            }
+        }
+    }
+
+    fn generate_function(&mut self, func: &Function) {
+        self.stack_slots.clear();
+        self.stack_size = 16; // Reset: 16 bytes for fp + lr
+
+        // Pre-allocate all vreg stack slots
+        for vreg in 0..func.num_vregs {
+            self.slot_for(vreg);
+        }
+
+        // Align stack to 16 bytes
+        let aligned_stack = (self.stack_size + 15) & !15;
+
+        self.emit_raw(&format!("    .globl {}", func.name));
+        self.emit_label(&func.name);
+
+        // Prologue: allocate frame, save fp and lr
+        self.emit_line(&format!("sub sp, sp, #{}", aligned_stack));
+        self.emit_line("stp x29, x30, [sp]");
+        self.emit_line("mov x29, sp");
+
+        // Save arguments to stack slots
+        for (i, param_name) in func.params.iter().enumerate() {
+            if i < AARCH64_ARG_REGS.len() && !param_name.is_empty() {
+                if let Some(&vreg) = func.locals.get(param_name) {
+                    let offset = self.slot_for(vreg);
+                    self.emit_line(&format!("str {}, [sp, #{}]", AARCH64_ARG_REGS[i], offset));
+                }
+            }
+        }
+
+        // Generate basic blocks
+        for block in &func.blocks {
+            self.generate_block(block, &func.name);
+        }
+    }
+
+    fn generate_block(&mut self, block: &BasicBlock, func_name: &str) {
+        self.emit_label(&format!(".L{}_{}", func_name, block.label));
+
+        for inst in &block.instructions {
+            self.generate_instruction(inst);
+        }
+
+        self.generate_terminator(&block.terminator, func_name);
+    }
+
+    fn generate_instruction(&mut self, inst: &Instruction) {
+        match inst {
+            Instruction::LoadImm { dest, value } => {
+                self.load_immediate("x0", *value);
+                self.store_x0(*dest);
+            }
+            Instruction::BinOp {
+                dest,
+                op,
+                left,
+                right,
+            } => {
+                self.load_operand_x0(left);
+                self.load_operand_x1(right);
+                match op {
+                    IrBinOp::Add => self.emit_line("add x0, x0, x1"),
+                    IrBinOp::Sub => self.emit_line("sub x0, x0, x1"),
+                    IrBinOp::Mul => self.emit_line("mul x0, x0, x1"),
+                    IrBinOp::Div => self.emit_line("sdiv x0, x0, x1"),
+                    IrBinOp::Mod => {
+                        self.emit_line("sdiv x2, x0, x1");
+                        self.emit_line("msub x0, x2, x1, x0");
+                    }
+                    IrBinOp::And => self.emit_line("and x0, x0, x1"),
+                    IrBinOp::Or => self.emit_line("orr x0, x0, x1"),
+                    IrBinOp::Xor => self.emit_line("eor x0, x0, x1"),
+                    IrBinOp::Shl => self.emit_line("lsl x0, x0, x1"),
+                    IrBinOp::Shr => self.emit_line("asr x0, x0, x1"),
+                }
+                self.store_x0(*dest);
+            }
+            Instruction::UnaryOp { dest, op, operand } => {
+                self.load_operand_x0(operand);
+                match op {
+                    IrUnaryOp::Neg => self.emit_line("neg x0, x0"),
+                    IrUnaryOp::Not => {
+                        self.emit_line("cmp x0, #0");
+                        self.emit_line("cset x0, eq");
+                    }
+                    IrUnaryOp::BitwiseNot => self.emit_line("mvn x0, x0"),
+                }
+                self.store_x0(*dest);
+            }
+            Instruction::Cmp {
+                dest,
+                op,
+                left,
+                right,
+            } => {
+                self.load_operand_x0(left);
+                self.load_operand_x1(right);
+                self.emit_line("cmp x0, x1");
+                let cond = match op {
+                    CmpOp::Eq => "eq",
+                    CmpOp::Ne => "ne",
+                    CmpOp::Lt => "lt",
+                    CmpOp::Le => "le",
+                    CmpOp::Gt => "gt",
+                    CmpOp::Ge => "ge",
+                };
+                self.emit_line(&format!("cset x0, {}", cond));
+                self.store_x0(*dest);
+            }
+            Instruction::Copy { dest, src } => {
+                self.load_operand_x0(src);
+                self.store_x0(*dest);
+            }
+            Instruction::Call { dest, func, args } => {
+                // Load arguments into registers (AAPCS64)
+                // We need to be careful about clobbering, so save args to stack first
+                // then load into arg registers
+                let num_args = args.len().min(AARCH64_ARG_REGS.len());
+
+                // For simplicity with <= 8 args, evaluate each into a temp vreg-like
+                // location, then load into arg regs
+                let mut saved_offsets = Vec::new();
+                for arg in args.iter() {
+                    self.load_operand_x0(arg);
+                    // Save to a temporary location by pushing (AArch64 style)
+                    self.emit_line("str x0, [sp, #-16]!");
+                    saved_offsets.push(());
+                }
+
+                // Pop back into argument registers in reverse
+                for i in (0..args.len()).rev() {
+                    if i < AARCH64_ARG_REGS.len() {
+                        self.emit_line(&format!("ldr {}, [sp], #16", AARCH64_ARG_REGS[i]));
+                    } else {
+                        self.emit_line("ldr x9, [sp], #16"); // discard
+                    }
+                }
+
+                let _ = (num_args, saved_offsets);
+
+                self.emit_line(&format!("bl {}", func));
+
+                if let Some(dest) = dest {
+                    self.store_x0(*dest);
+                }
+            }
+            Instruction::LoadStringAddr { dest, label } => {
+                self.emit_line(&format!("adrp x0, {}", label));
+                self.emit_line(&format!("add x0, x0, :lo12:{}", label));
+                self.store_x0(*dest);
+            }
+            Instruction::Alloca { dest, size } => {
+                self.emit_line(&format!("sub sp, sp, #{}", size));
+                self.emit_line("mov x0, sp");
+                self.store_x0(*dest);
+            }
+            Instruction::Store { addr, value } => {
+                self.load_operand_x0(value);
+                let addr_offset = self.slot_for(*addr);
+                self.emit_line(&format!("ldr x1, [sp, #{}]", addr_offset));
+                self.emit_line("str x0, [x1]");
+            }
+            Instruction::Load { dest, addr } => {
+                let addr_offset = self.slot_for(*addr);
+                self.emit_line(&format!("ldr x0, [sp, #{}]", addr_offset));
+                self.emit_line("ldr x0, [x0]");
+                self.store_x0(*dest);
+            }
+        }
+    }
+
+    fn generate_terminator(&mut self, term: &Terminator, func_name: &str) {
+        match term {
+            Terminator::Return(val) => {
+                if let Some(val) = val {
+                    self.load_operand_x0(val);
+                }
+                // Epilogue: restore fp, lr, deallocate frame
+                self.emit_line("ldp x29, x30, [sp]");
+                let aligned_stack = (self.stack_size + 15) & !15;
+                self.emit_line(&format!("add sp, sp, #{}", aligned_stack));
+                self.emit_line("ret");
+            }
+            Terminator::Jump(label) => {
+                self.emit_line(&format!("b .L{}_{}", func_name, label));
+            }
+            Terminator::Branch {
+                condition,
+                true_label,
+                false_label,
+            } => {
+                self.load_operand_x0(condition);
+                self.emit_line("cmp x0, #0");
+                self.emit_line(&format!("b.ne .L{}_{}", func_name, true_label));
+                self.emit_line(&format!("b .L{}_{}", func_name, false_label));
+            }
+            Terminator::None => {}
+        }
+    }
 }
 
 #[cfg(test)]
@@ -365,7 +662,7 @@ mod tests {
         let asm = generate(&module);
         assert!(asm.contains(".globl main"));
         assert!(asm.contains("main:"));
-        assert!(asm.contains("$42"));
+        assert!(asm.contains("42"));
         assert!(asm.contains("ret"));
     }
 
@@ -382,7 +679,37 @@ mod tests {
         let program = parser::parse(tokens).unwrap();
         let module = ir::lower(&program);
         let asm = generate(&module);
-        assert!(asm.contains("call printf"));
+        assert!(asm.contains("printf"));
         assert!(asm.contains("Hello, World!"));
+    }
+
+    #[test]
+    fn test_codegen_arithmetic() {
+        let tokens = lexer::lex("int main() { return 2 + 3 * 4; }").unwrap();
+        let program = parser::parse(tokens).unwrap();
+        let module = ir::lower(&program);
+        let asm = generate(&module);
+        assert!(asm.contains("ret"));
+    }
+
+    #[test]
+    fn test_codegen_if_else() {
+        let source = "int main() { if (1 > 0) { return 1; } else { return 0; } }";
+        let tokens = lexer::lex(source).unwrap();
+        let program = parser::parse(tokens).unwrap();
+        let module = ir::lower(&program);
+        let asm = generate(&module);
+        assert!(asm.contains("cmp") || asm.contains("cmpq"));
+    }
+
+    #[test]
+    fn test_codegen_while_loop() {
+        let source = "int main() { int i = 0; while (i < 10) { i = i + 1; } return i; }";
+        let tokens = lexer::lex(source).unwrap();
+        let program = parser::parse(tokens).unwrap();
+        let module = ir::lower(&program);
+        let asm = generate(&module);
+        // Should have loop labels
+        assert!(asm.contains(".L"));
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -191,6 +191,12 @@ impl FunctionBuilder {
     }
 
     fn start_block(&mut self, label: Label) {
+        // If the current block hasn't been terminated yet (e.g., an unreachable
+        // merge block after if/else where both branches return), emit it now
+        // with an implicit return so all labels are defined in the output.
+        if !self.blocks.iter().any(|b| b.label == self.current_label) {
+            self.terminate(Terminator::Return(Some(Operand::Immediate(0))));
+        }
         self.current_label = label;
         self.current_block = Vec::new();
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,225 @@
+/// Integration tests: compile C programs using rustcc and verify they run correctly.
+use std::fs;
+use std::process::Command;
+
+/// Compile a C source string, run the resulting binary, return (exit_code, stdout).
+fn compile_and_run(source: &str) -> (i32, String) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let c_path = dir.path().join("test.c");
+    let out_path = dir.path().join("test_bin");
+
+    fs::write(&c_path, source).expect("write test.c");
+
+    let rustcc = env!("CARGO_BIN_EXE_rustcc");
+
+    let compile = Command::new(rustcc)
+        .args(["-o", out_path.to_str().unwrap(), c_path.to_str().unwrap()])
+        .output()
+        .expect("run rustcc");
+
+    if !compile.status.success() {
+        let stderr = String::from_utf8_lossy(&compile.stderr);
+        panic!("Compilation failed:\n{}", stderr);
+    }
+
+    let run = Command::new(out_path.to_str().unwrap())
+        .output()
+        .expect("run compiled binary");
+
+    let exit_code = run.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&run.stdout).to_string();
+
+    (exit_code, stdout)
+}
+
+// === Return constants ===
+
+#[test]
+fn test_return_42() {
+    let (code, _) = compile_and_run("int main() { return 42; }");
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_return_0() {
+    let (code, _) = compile_and_run("int main() { return 0; }");
+    assert_eq!(code, 0);
+}
+
+// === Arithmetic ===
+
+#[test]
+fn test_add() {
+    let (code, _) = compile_and_run("int main() { return 10 + 20; }");
+    assert_eq!(code, 30);
+}
+
+#[test]
+fn test_sub() {
+    let (code, _) = compile_and_run("int main() { return 50 - 8; }");
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_mul() {
+    let (code, _) = compile_and_run("int main() { return 6 * 7; }");
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_div() {
+    let (code, _) = compile_and_run("int main() { return 84 / 2; }");
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_mod() {
+    let (code, _) = compile_and_run("int main() { return 47 % 10; }");
+    assert_eq!(code, 7);
+}
+
+#[test]
+fn test_precedence() {
+    let (code, _) = compile_and_run("int main() { return 2 + 3 * 4; }");
+    assert_eq!(code, 14);
+}
+
+// === Variables ===
+
+#[test]
+fn test_var_decl() {
+    let (code, _) = compile_and_run("int main() { int x = 42; return x; }");
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_var_assign() {
+    let (code, _) = compile_and_run("int main() { int x = 10; x = 42; return x; }");
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_multiple_vars() {
+    let (code, _) =
+        compile_and_run("int main() { int a = 10; int b = 20; int c = 12; return a + b + c; }");
+    assert_eq!(code, 42);
+}
+
+// === Comparisons ===
+
+#[test]
+fn test_eq_true() {
+    let (code, _) = compile_and_run("int main() { return 5 == 5; }");
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn test_eq_false() {
+    let (code, _) = compile_and_run("int main() { return 5 == 3; }");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn test_ne() {
+    let (code, _) = compile_and_run("int main() { return 5 != 3; }");
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn test_lt() {
+    let (code, _) = compile_and_run("int main() { return 3 < 5; }");
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn test_gt() {
+    let (code, _) = compile_and_run("int main() { return 5 > 3; }");
+    assert_eq!(code, 1);
+}
+
+// === Control flow ===
+
+#[test]
+fn test_if_true() {
+    let (code, _) = compile_and_run("int main() { if (1) { return 42; } return 0; }");
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_if_false() {
+    let (code, _) = compile_and_run("int main() { if (0) { return 42; } return 0; }");
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn test_if_else() {
+    let (code, _) =
+        compile_and_run("int main() { int x = 10; if (x > 5) { return 1; } else { return 0; } }");
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn test_while_loop() {
+    let (code, _) = compile_and_run(
+        "int main() { int i = 0; int sum = 0; while (i < 10) { sum = sum + i; i = i + 1; } return sum; }",
+    );
+    assert_eq!(code, 45);
+}
+
+#[test]
+fn test_for_loop() {
+    let (code, _) = compile_and_run(
+        "int main() { int sum = 0; for (int i = 0; i < 5; i = i + 1) { sum = sum + i; } return sum; }",
+    );
+    assert_eq!(code, 10);
+}
+
+// === Unary operators ===
+
+#[test]
+fn test_negate() {
+    let (code, _) = compile_and_run("int main() { return -(-42); }");
+    assert_eq!(code, 42);
+}
+
+// === Function calls ===
+
+#[test]
+fn test_function_call() {
+    let (code, _) = compile_and_run(
+        "int add(int a, int b) { return a + b; } int main() { return add(20, 22); }",
+    );
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_hello_world() {
+    let source = r#"
+        int printf(const char *fmt, ...);
+        int main() {
+            printf("Hello, World!\n");
+            return 0;
+        }
+    "#;
+    let (code, stdout) = compile_and_run(source);
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "Hello, World!");
+}
+
+// === Complex programs ===
+
+#[test]
+fn test_nested_if() {
+    let (code, _) = compile_and_run(
+        "int main() { int x = 10; int y = 20; if (x > 5) { if (y > 15) { return 42; } } return 0; }",
+    );
+    assert_eq!(code, 42);
+}
+
+#[test]
+fn test_complex_expr() {
+    let (code, _) =
+        compile_and_run("int main() { int x = 2; int y = 3; return (x + y) * (x + y) - x * y; }");
+    // (2+3)*(2+3) - 2*3 = 25 - 6 = 19
+    assert_eq!(code, 19);
+}


### PR DESCRIPTION
## Summary
- Add AArch64 code generator alongside the existing x86-64 backend (AAPCS64 ABI)
- Architecture is auto-detected at compile time via `cfg!(target_arch)`
- Fix IR bug: unreachable merge blocks after if/else where both branches return caused undefined label errors in generated assembly
- Add 26 end-to-end integration tests that compile C programs and verify correctness
- Add `tempfile` dev-dependency for integration test temp dirs

## What this enables
The compiler now works on both x86-64 and AArch64 machines. All 43 tests pass (17 unit + 26 integration).

## Test plan
- [x] `cargo test` passes all 43 tests (17 unit + 26 integration)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] End-to-end: `rustcc -o test test.c && ./test` produces correct results on AArch64

Closes #10, closes #11

Generated with [Claude Code](https://claude.com/claude-code)