### PR TITLE
Fix preprocessor integration tests

### DIFF
--- a/tests/preprocessor_define/main.c
+++ b/tests/preprocessor_define/main.c
@@ -1,4 +1,4 @@
-#include <stdio.h>
+int printf(const char *fmt, ...);
 
 #define VALUE 42
 #define DOUBLE(x) ((x) * 2)

--- a/tests/preprocessor_ifdef/main.c
+++ b/tests/preprocessor_ifdef/main.c
@@ -1,4 +1,4 @@
-#include <stdio.h>
+int printf(const char *fmt, ...);
 
 #define FEATURE_A
 

--- a/tests/preprocessor_include/main.c
+++ b/tests/preprocessor_include/main.c
@@ -1,4 +1,4 @@
-#include <stdio.h>
+int printf(const char *fmt, ...);
 #include "myheader.h"
 
 int main() {


### PR DESCRIPTION
## Summary
- Replace `#include <stdio.h>` with `int printf(const char *fmt, ...);` forward declaration in preprocessor integration tests
- Our preprocessor can't resolve system headers, so use the same pattern as other integration tests

## Test plan
- [x] All 69 tests pass (`cargo test`)
- [x] Preprocessor tests compile and run correctly with forward declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)