### PR TITLE
Fix cargo fmt violations in integration_tests.rs

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -257,9 +257,8 @@ fn test_do_while() {
 #[test]
 fn test_do_while_once() {
     // do-while always executes body at least once, even if condition is false
-    let (code, _) = compile_and_run(
-        "int main() { int x = 0; do { x = 42; } while (0); return x; }",
-    );
+    let (code, _) =
+        compile_and_run("int main() { int x = 0; do { x = 42; } while (0); return x; }");
     assert_eq!(code, 42);
 }
 
@@ -286,17 +285,13 @@ fn test_continue_in_for() {
 
 #[test]
 fn test_post_increment() {
-    let (code, _) = compile_and_run(
-        "int main() { int x = 41; x++; return x; }",
-    );
+    let (code, _) = compile_and_run("int main() { int x = 41; x++; return x; }");
     assert_eq!(code, 42);
 }
 
 #[test]
 fn test_post_decrement() {
-    let (code, _) = compile_and_run(
-        "int main() { int x = 43; x--; return x; }",
-    );
+    let (code, _) = compile_and_run("int main() { int x = 43; x--; return x; }");
     assert_eq!(code, 42);
 }
 


### PR DESCRIPTION
## Summary
- Run `cargo fmt` on `tests/integration_tests.rs` to fix format check failures in CI
- This was missed by PR #33 which only formatted `sema.rs` and `parser.rs`

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)